### PR TITLE
Add repl

### DIFF
--- a/pybox.py
+++ b/pybox.py
@@ -5,13 +5,13 @@ from thread2 import Thread
 from copy import deepcopy
 from io import StringIO
 from contextlib import redirect_stdout
-from typing import Callable
+from typing import Callable, Any
 
 from pybox_util import safe_builtins, safe_libraries, generate_pyfuncs
 
 
 class PyBox:
-    def __init__(self, custom_builtins: dict[str, any] = safe_builtins, libraries: list[str] = safe_libraries):
+    def __init__(self, custom_builtins: dict[str, Any] = safe_builtins, libraries: list[str] = safe_libraries):
         self.variables = {'__builtins__': deepcopy(custom_builtins),
                           **{str(lib): __import__(lib) for lib in libraries},
                           **generate_pyfuncs()}
@@ -30,7 +30,6 @@ class PyBox:
         def _exec():
             ret_val = 0
             try:
-                time.sleep(0.0001)
                 f = StringIO()
                 with redirect_stdout(f):
                     exec(code, self.variables)
@@ -38,14 +37,16 @@ class PyBox:
                 self.printer(s)
             except BaseException:
                 exc_type, exc_value, exc_traceback = sys.exc_info()
-                ret_val = 1
-                exception_array = traceback.format_exc()
-                i = tuple(1 if 'File "<string>", line' in line else 0 for line in exception_array.splitlines()).index(1)
-                exception_str = '\n'.join([line.strip() for line in exception_array.splitlines()[i:]])
-                if self.err_printer is not None:
-                    self.err_printer(exception_str)
-                else:
-                    self.printer(exception_str)
+                if not isinstance(exc_value, SystemExit):
+                    ret_val = 1
+                    exception_array = traceback.format_exc()
+                    i = tuple(1 if 'File "<string>", line' in line else 0 for line in exception_array.splitlines()).index(1)
+                    exception_str = '\n'.join([line.strip() for line in exception_array.splitlines()[i:]])
+                    if self.err_printer is not None:
+                        self.err_printer(exception_str)
+                    else:
+                        self.printer(exception_str)
+
             exec_time = (time.perf_counter_ns()-start_time)/1e9
             self.total_time += exec_time
             callback(ret_val, exec_time)
@@ -61,4 +62,5 @@ class PyBox:
                     callback(2, exec_time)
             abort_thread = Thread(target=_abort)
             abort_thread.start()
+        thread.join()
 

--- a/repl.py
+++ b/repl.py
@@ -1,0 +1,60 @@
+from typing import Any
+
+from pybox import PyBox
+
+def is_indentation_error(code: str) -> bool:
+    try:
+        compile(code, '<string>', 'exec')
+    except IndentationError:
+        return True
+    except SyntaxError:
+        return False
+    else:
+        return False
+
+def get_input() -> str:
+    first_line = input('!>> ')
+    if is_indentation_error(first_line):
+        code = [first_line]
+        while True:
+            try:
+                line = input('... ')
+            except EOFError:
+                break
+            if line == '':
+                break
+
+            code.append(line)
+        code = '\n'.join(code)
+    else:
+        code = first_line
+    return code
+
+def repl(box: PyBox = None, abort_time: int = 0) -> None:
+    if box is None:
+        box = PyBox()
+    elif not isinstance(box, PyBox):
+        raise TypeError(f'box arg must be of type PyBox not {box.__class__!r}') 
+
+    def next_repl(ret_val: int, exc_time: float) -> None:
+        if ret_val == 2:
+            print('aborted')
+        else:
+            print(f'executed in {exc_time*1e6:.5f}μs')
+        
+        try:
+            _repl()
+        except EOFError:
+            print('Bye!')
+
+    def _repl() -> None:
+        code = get_input()
+        while code == '':
+            code = get_input()
+
+        box.exec(code, callback=next_repl, abort_time=abort_time)
+    
+    try:
+        _repl()
+    except EOFError:
+        print('Bye!')

--- a/thread2.py
+++ b/thread2.py
@@ -6,7 +6,7 @@ import ctypes
 def _async_raise(tid, exctype):
     if not inspect.isclass(exctype):
         raise TypeError('Only types can be raised (not instances)')
-    res = ctypes.pythonapi.PyThreadState_SetAsyncExc(tid, ctypes.py_object(exctype))
+    res = ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_long(tid), ctypes.py_object(exctype))
     if res == 0:
         raise ValueError('invalid thread id')
     elif res != 1:


### PR DESCRIPTION
This also fixes a couple of things that I ran into.
1. The thread id is now put through `ctypes.c_long` so it doesn't always raise a `ValueError`
2. `PyBox.exec` now blocks until the function is done.